### PR TITLE
UI Polish

### DIFF
--- a/textprofilerfrontend/src/components/charts/DateChart.svelte
+++ b/textprofilerfrontend/src/components/charts/DateChart.svelte
@@ -2,13 +2,15 @@
   import * as vg from "@uwdata/vgplot";
   import { afterUpdate, onDestroy } from "svelte";
   import { mosaicSelection } from "../../stores";
-  import { getPlot } from "./chartUtils";
+  import { getPlot, dateLayout } from "./chartUtils";
 
   export let columnName: string;
   export let mainDatasetName: string;
 
   let el: HTMLElement;
   let plotWrapper;
+
+  const layout = dateLayout;
 
   // FUTURE: if vg.bin() works for dates might be nice here so less crowded line...
   function renderChart(datasetName: string, cName: string) {
@@ -18,14 +20,14 @@
       vg.lineY(vg.from(fromClause, { filterBy: $mosaicSelection }), {
         x: cName,
         y: vg.count(),
-        stroke: "steelblue",
+        stroke: layout.color,
         curve: "monotone-x",
       }),
       vg.intervalX({ as: $mosaicSelection }),
       vg.xDomain(vg.Fixed),
-      vg.marginLeft(55),
-      vg.width(400),
-      vg.height(150),
+      vg.marginLeft(layout.marginLeft),
+      vg.width(layout.width),
+      vg.height(layout.height),
     );
 
     el.replaceChildren(plotWrapper.element);

--- a/textprofilerfrontend/src/components/charts/Histogram.svelte
+++ b/textprofilerfrontend/src/components/charts/Histogram.svelte
@@ -3,12 +3,14 @@
   import { afterUpdate, onDestroy } from "svelte";
   import { mosaicSelection } from "../../stores";
   import { getDatasetName } from "../../shared/utils";
-  import { getPlot } from "./chartUtils";
+  import { getPlot, histogramLayout } from "./chartUtils";
 
   export let columnName: string;
   export let mainDatasetName: string;
   export let showBackground = true;
   export let plotNulls = false;
+
+  const layout = histogramLayout;
 
   let el: HTMLElement;
   let plotWrapper;
@@ -25,37 +27,39 @@
     if (showBackground) {
       plotWrapper = getPlot(
         vg.rectY(vg.from(fromClause), {
-          x: vg.bin(columnName),
+          x: vg.bin(columnName, { steps: layout.steps }),
           y: vg.count(),
           fill: "#ccc",
           fillOpacity: 0.4,
-          inset: 0.5,
+          inset: layout.inset,
         }),
         vg.rectY(vg.from(fromClause, { filterBy: $mosaicSelection }), {
-          x: vg.bin(columnName),
+          x: vg.bin(columnName, { steps: layout.steps }),
           y: vg.count(),
-          fill: "steelblue",
-          inset: 0.5,
+          fill: layout.color,
+          inset: layout.inset,
         }),
         vg.intervalX({ as: $mosaicSelection }),
         vg.xDomain(vg.Fixed),
-        vg.marginLeft(55),
-        vg.width(400),
-        vg.height(150),
+        vg.marginLeft(layout.marginLeft),
+        vg.width(layout.width),
+        vg.height(layout.height),
+        vg.axisY({ textOverflow: "ellipsis", lineWidth: layout.axisLineWidth }),
       );
     } else {
       plotWrapper = getPlot(
         vg.rectY(vg.from(fromClause, { filterBy: $mosaicSelection }), {
-          x: vg.bin(columnName),
+          x: vg.bin(columnName, { steps: layout.steps }),
           y: vg.count(),
-          fill: "steelblue",
-          inset: 0.5,
+          fill: layout.color,
+          inset: layout.inset,
         }),
         vg.intervalX({ as: $mosaicSelection }),
         vg.xDomain(vg.Fixed),
-        vg.marginLeft(55),
-        vg.width(400),
-        vg.height(150),
+        vg.marginLeft(layout.marginLeft),
+        vg.width(layout.width),
+        vg.height(layout.height),
+        vg.axisY({ textOverflow: "ellipsis", lineWidth: layout.axisLineWidth }),
       );
     }
 

--- a/textprofilerfrontend/src/components/charts/ScatterProjection.svelte
+++ b/textprofilerfrontend/src/components/charts/ScatterProjection.svelte
@@ -3,11 +3,13 @@
   import { afterUpdate, onDestroy } from "svelte";
   import { mosaicSelection, clearColumnSelections } from "../../stores";
   import { getDatasetName, getUUID } from "../../shared/utils";
-  import { getPlot } from "./chartUtils";
+  import { getPlot, projectionLayout } from "./chartUtils";
 
   export let columnName: string;
   export let mainDatasetName: string;
   export let plotNulls = true;
+
+  const layout = projectionLayout;
 
   let el: HTMLElement;
   let plotWrapper;
@@ -58,15 +60,15 @@
         x: "umap_x",
         y: "umap_y",
         r: 1,
-        fill: "steelblue",
+        fill: layout.color,
       }),
       vg.xAxis(null),
       vg.yAxis(null),
       vg.highlight({ by: selection, opacity: 0.1 }),
       vg.intervalXY({ as: selection }),
       vg.intervalXY({ as: $mosaicSelection }),
-      vg.width(400),
-      vg.height(280),
+      vg.width(layout.width),
+      vg.height(layout.height),
     );
 
     el.replaceChildren(plotWrapper.element);

--- a/textprofilerfrontend/src/components/charts/chartUtils.ts
+++ b/textprofilerfrontend/src/components/charts/chartUtils.ts
@@ -12,3 +12,56 @@ export function getPlot(...directives) {
   p.marks.forEach((mark) => vg.coordinator().connect(mark));
   return p;
 }
+
+
+const lightModeStyles: Record<string, string> = {
+  primaryColor: "#4768B5",
+  secondaryColor: "#F3752B",
+};
+
+export const categoricalLayout: Record<string, any> = {
+    width: 420,
+    marginLeft: 80,
+    marginRight: 40,
+    marginTop: 10,
+    marginBottom: 30,
+    axisLineWidth: 7, //7 for 80 marginLeft
+    textLineWidth: 3, //3 for 40 marginRight
+    barHeight: 15, //thin bars:
+    inset: 0,
+    color: lightModeStyles.primaryColor,
+}
+
+export const dateLayout: Record<string, any> = {
+  width: 420,
+  height: 150,
+  marginLeft: 55,
+  marginRight: 40,
+  axisLineWidth: 4, //7 for 80 marginLeft
+  textLineWidth: 3, //3 for 40 marginRight
+  inset: 0.5,
+  color: lightModeStyles.secondaryColor,
+}
+
+export const histogramLayout: Record<string, any> = {
+  width: 420,
+  height: 150,
+  marginLeft: 55,
+  marginRight: 40,
+  axisLineWidth: 4, //7 for 80 marginLeft
+  textLineWidth: 3, //3 for 40 marginRight
+  inset: 0.5,
+  steps: 50, //thin bars: bin(thresholds) default=25 in bin.js
+  color: lightModeStyles.secondaryColor,
+}
+
+export const projectionLayout: Record<string, any> = {
+  width: 420,
+  height: 280,
+  marginLeft: 55,
+  marginRight: 40,
+  axisLineWidth: 4, //7 for 80 marginLeft
+  textLineWidth: 3, //3 for 40 marginRight
+  inset: 0.5,
+  color: lightModeStyles.primaryColor,
+}

--- a/textprofilerfrontend/src/database/db.ts
+++ b/textprofilerfrontend/src/database/db.ts
@@ -191,6 +191,16 @@ export class DatabaseConnection {
     return resultMap;
   }
 
+  async getColCount(
+    fromClause: any,
+    cName: any,
+  ): Promise<number> {
+    // let q = vg.Query.from(fromClause).select({count: vg.sql`COUNT(DISTINCT ${vg.column(cName)})`});
+    let q = vg.Query.from(fromClause).select({count: vg.sql`COUNT(DISTINCT CASE WHEN ${vg.column(cName)} IS NULL THEN 'null' ELSE ${vg.column(cName)} END)`});
+    let r = await vg.coordinator().query(q, { type: "json" });
+    return r[0]?.["count"];
+  }
+
   async getDocsByID(dsInfo: DatasetInfo, ids: any[]): Promise<any[]> {
     let fromClause = dsInfo.name;
 


### PR DESCRIPTION
## UI Polish for Charts
Overall make the charts look nicer. Some ideas -- 
- [x] Make them less wide and less tall
- [x] Make bars smaller (less tall) on categorical charts
- [x] Text visible / better text cutoff on axis (ideally should cut off with ellipsis like "long caption th...")
- [x] On categorical charts, cannot read the text number next to the bar if very long (gets cut off)
- [x] Use unique colors for categorical and number charts, or maybe unique color per text column? Idk colors are just ok
   - It seems that having a unique color per text column is too chaotic. Using unique colors for categorical and numerical charts seems like a good idea, so I've tested it with two colors for now! If you don't like these colors, we can revert back to steelblue or discuss other colors later.
   - <img width="1470" alt="image" src="https://github.com/cmudig/TextProfiler/assets/15666289/0715b1b0-3b41-4afb-afdb-036e68917e2c">

 close #32